### PR TITLE
Add support for `npm run dev`

### DIFF
--- a/demo/dev/auth-button.htm
+++ b/demo/dev/auth-button.htm
@@ -20,6 +20,7 @@
         document.querySelectorAll('[data-funding-source]').forEach(button => {
             button.addEventListener('click', () => {
                 const instance = paypal.Auth({
+                    ...xprops,
                     onApprove: () => {
                         console.log('Approved');
                         instance.close();

--- a/demo/dev/auth-button.htm
+++ b/demo/dev/auth-button.htm
@@ -3,18 +3,18 @@
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <script src="https://localhost.paypal.com:9000/sdk.js?client-id=alc_client1"></script>
-    <script src="https://localhost.paypal.com:9000/button.js"></script>
-    <script src="https://localhost.paypal.com:9000/jsx-pragmatic.js"></script>
+    <script src="https://localhost.paypal.com:9001/sdk.js?client-id=alc_client1"></script>
+    <script src="https://localhost.paypal.com:9001/button.js"></script>
+    <script src="https://localhost.paypal.com:9001/jsx-pragmatic.js"></script>
 </head>
 
 <body>
     <script>
         document.write(button.AuthButton({
             ...xprops,
-            content: {
-                connectLabel: 'Connect'
-            }
+            customLabel: 'Connect with PayPal',
+            displayLabel: true,
+            onClick: () => {}
         }).render(jsx.html()));
 
         document.querySelectorAll('[data-funding-source]').forEach(button => {
@@ -29,7 +29,7 @@
                         instance.close();
                     }
                 });
-                
+
                 instance.renderTo(window.parent, 'body');
             });
         });

--- a/demo/dev/auth.htm
+++ b/demo/dev/auth.htm
@@ -3,7 +3,7 @@
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <script src="https://localhost.paypal.com:9000/sdk.js?client-id=alc_client1"></script>
+    <script src="https://localhost.paypal.com:9001/sdk.js?client-id=alc_client1"></script>
 </head>
 
 <body>

--- a/demo/dev/index.htm
+++ b/demo/dev/index.htm
@@ -3,7 +3,7 @@
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <script src="https://localhost.paypal.com:9000/sdk.js?client-id=alc_client1"></script>
+    <script src="https://localhost.paypal.com:9001/sdk.js?client-id=alc_client1"></script>
 </head>
 
 <body>
@@ -11,6 +11,8 @@
 
     <script>
         paypal.AuthButton({
+            scopes: ['email'],
+            responseType: 'code',
             style: {
                 label: 'connect'
             }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "PayPal Identity components, for integrating auth products.",
   "main": "index.js",
   "scripts": {
-    "dev": "babel-node $(npm bin)/webpack-dev-server --config webpack.config.dev.js --port 9000 --host localhost.paypal.com --open-page demo/dev/index.htm --https --hot=false --inline=false",
+    "dev": "babel-node $(npm bin)/webpack-dev-server --config webpack.config.dev.js --port 9001 --host localhost.paypal.com --open-page demo/dev/index.htm --https --hot=false --inline=false",
     "lint": "eslint --ext .js --ext .jsx src/ test/ *.js",
     "flow-typed": "rm -rf flow-typed && flow-typed install",
     "flow": "flow",

--- a/src/ui/button/props.js
+++ b/src/ui/button/props.js
@@ -121,7 +121,7 @@ export type ButtonProps = {|
         nonce? : string
     |}
    |};
-   
+
 export type ButtonPropsInputs = {|
     clientID : string,
     fundingSource? : $Values<typeof FUNDING>,
@@ -162,7 +162,7 @@ export const DEFAULT_PROPS = {
 const ALLOWED_SHAPES = values(BUTTON_SHAPE);
 
 export function normalizeButtonStyle(props : ?ButtonPropsInputs, style : ButtonStyleInputs) : ButtonStyle {
- 
+
     if (!style) {
         throw new Error(`Expected props.style to be set`);
     }
@@ -176,7 +176,7 @@ export function normalizeButtonStyle(props : ?ButtonPropsInputs, style : ButtonS
     if (fundingSource === FUNDING.CREDIT) {
         ALLOWED_COLORS = [ BUTTON_COLOR.DARKBLUE ];
     }
-    
+
     const {
         label,
         color = fundingSource === FUNDING.CREDIT ? BUTTON_COLOR.DARKBLUE : BUTTON_COLOR.BLUE,
@@ -194,7 +194,7 @@ export function normalizeButtonStyle(props : ?ButtonPropsInputs, style : ButtonS
         if (typeof height !== 'number') {
             throw new TypeError(`Expected style.height to be a number, got: ${ height }`);
         }
-        
+
         const [ minHeight, maxHeight ] = [ 35, 50 ];
 
         if (height < minHeight || height > maxHeight) {

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -11,7 +11,7 @@ const FILE_NAME = 'sdk';
 
 const PROTOCOL = 'https';
 const HOSTNAME = 'localhost.paypal.com';
-const PORT = 9000;
+const PORT = 9001;
 
 const WEBPACK_CONFIG_DEV : WebpackConfig = getWebpackConfig({
     entry:         './paypal.dev.js',
@@ -23,6 +23,7 @@ const WEBPACK_CONFIG_DEV : WebpackConfig = getWebpackConfig({
         ...globals,
         ...testGlobals,
         __PROTOCOL__:        PROTOCOL,
+        __PAYPAL_DOMAIN__:   'https://localhost.paypal.com:9001',
         __HOST__:            `${ HOSTNAME }:${ PORT }`,
         __SDK_HOST__:        `${ HOSTNAME }:${ PORT }`,
         __PORT__:            PORT,


### PR DESCRIPTION
This PR fixes the `npm run dev` command so it renders the buttons.

Note that there is a label issue where the full label is not displaying. Here's a screenshot
<img width="826" alt="Screen Shot 2021-10-06 at 1 50 21 PM" src="https://user-images.githubusercontent.com/534034/136265072-d793b673-851e-4bbb-97b5-6f699bccff7f.png">

@Karthickgreets99 