### PR TITLE
pass hostname instread entire url

### DIFF
--- a/src/zoid/auth/config.js
+++ b/src/zoid/auth/config.js
@@ -10,5 +10,5 @@ export function getRedirectUrl(): string {
 }
 
 export function getMerchantDomain(): string {
-  return window.location.href;
+  return window.location.hostname;
 }


### PR DESCRIPTION
Change list:
- in previous PR entire merchant url was passed using `window.location.href`, we don't need the entire url, only domain is needed, refactoring the return var to be from `window.location.hostname`